### PR TITLE
[INEWS-2894] iNews - Replace Circle CI with GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       commit_changelog:
         required: false
         type: boolean
-        default: false
+        default: true
       update_wiki:
         required: false
         type: boolean
@@ -16,8 +16,6 @@ on:
         required: true
       NEW_RELIC_DEPLOYMENT_ENTITY_GUID:
         required: true
-      NEW_RELIC_PREPROD_ENTITY_GUID:
-        required: false
 
 permissions: write-all
 
@@ -33,10 +31,8 @@ jobs:
       # Create git tag from timestamp YYYY-MM-DDTHH:MM:SS
       - name: Get current date and time
         id: datetime
-        if: ${{ github.ref_name == 'production' }}
         run: echo "TAG_NAME=$(date +'%Y-%m-%dT%H.%M.%S')" >> "$GITHUB_OUTPUT"
       - name: Create and push tag
-        if: ${{ github.ref_name == 'production' }}
         uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ steps.datetime.outputs.TAG_NAME }}
@@ -45,19 +41,16 @@ jobs:
           force_push_tag: true
       - name: Get latest tag
         id: get_latest_tag
-        if: ${{ github.ref_name == 'production' }}
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           semver_only: false
       - name: Get second latest tag
         id: get_second_latest_tag
-        if: ${{ github.ref_name == 'production' }}
         run: |
           SECOND_LATEST_TAG=$(git for-each-ref --sort=-taggerdate --format '%(refname:short)' refs/tags | sed -n 2p)
           echo "second_latest_tag=$SECOND_LATEST_TAG" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG
         id: changelog
-        if: ${{ github.ref_name == 'production' }}
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
@@ -68,7 +61,6 @@ jobs:
           excludeTypes: build,
           reverseOrder: true
       - name: Create Release
-        if: ${{ github.ref_name == 'production' }}
         uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true
@@ -79,7 +71,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.get_latest_tag.outputs.tag }}
       - name: Commit CHANGELOG.md
-        if: ${{ github.ref_name == 'production' && inputs.commit_changelog }} 
+        if: ${{ inputs.commit_changelog }} 
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: preprod
@@ -87,7 +79,7 @@ jobs:
           file_pattern: CHANGELOG.md
 
       - name: Update Wiki
-        if: ${{ github.ref_name == 'production' && inputs.update_wiki }}
+        if: ${{ inputs.update_wiki }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -115,7 +107,6 @@ jobs:
         id: timestamp
         run: echo "NOW_MS=$(date +%s%3N)" >> $GITHUB_OUTPUT
       - name: Set New Relic deployment marker
-        if: ${{ github.ref_name == 'production' }}
         uses: newrelic/deployment-marker-action@v2.6.1
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
@@ -125,31 +116,4 @@ jobs:
           changelog: "https://github.com/${{ github.repository }}/blob/preprod/CHANGELOG.md"
           description: "Automated Release via Github Actions"
           user: "${{ github.actor }}"
-          timestamp: "${{ steps.timestamp.outputs.NOW_MS }}"
-
-      # Set New Relic deployment marker for Preprod.
-      # Requires NEW_RELIC_PREPROD_ENTITY_GUID secret to be set.
-
-      # Get commit info for changelog and user.
-      - name: Get commit info
-        id: commit_info
-        if: ${{ github.ref_name == 'preprod' && secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
-        run: |
-          CHANGELOG=$(git log ${{ github.sha }} --oneline -1)
-          USER=$(git log ${{ github.sha }} --format="%an" -1)
-          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "user=$USER" >> $GITHUB_OUTPUT
-
-      # Set the Preprod Marker.
-      - name: Set Preprod New Relic deployment marker
-        if: ${{ github.ref_name == 'preprod' && secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
-        uses: newrelic/deployment-marker-action@v2.6.1
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          region: "US"
-          guid: ${{ secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
-          version: "${{ github.sha }}"
-          changelog: "${{ steps.commit_info.outputs.changelog }}"
-          description: "Release via Github Actions"
-          user: "${{ steps.commit_info.outputs.user }}"
           timestamp: "${{ steps.timestamp.outputs.NOW_MS }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   workflow_call:
     inputs:
+      update_changelog:
+        required: false
+        type: boolean
+        default: false
       update_wiki:
         required: false
         type: boolean
@@ -53,7 +57,7 @@ jobs:
           echo "second_latest_tag=$SECOND_LATEST_TAG" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG
         id: changelog
-        if: ${{ github.ref_name == 'production' }}
+        if: ${{ github.ref_name == 'production' && inputs.update_changelog }}
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
         required: true
       NEW_RELIC_DEPLOYMENT_ENTITY_GUID:
         required: true
+      NEW_RELIC_PREPROD_ENTITY_GUID:
+        required: false
 
 permissions: write-all
 
@@ -22,8 +24,10 @@ jobs:
       # Create git tag from timestamp YYYY-MM-DDTHH:MM:SS
       - name: Get current date and time
         id: datetime
+        if: ${{ github.ref_name == 'production' }}
         run: echo "TAG_NAME=$(date +'%Y-%m-%dT%H.%M.%S')" >> "$GITHUB_OUTPUT"
       - name: Create and push tag
+        if: ${{ github.ref_name == 'production' }}
         uses: rickstaa/action-create-tag@v1
         with:
           tag: ${{ steps.datetime.outputs.TAG_NAME }}
@@ -32,16 +36,19 @@ jobs:
           force_push_tag: true
       - name: Get latest tag
         id: get_latest_tag
+        if: ${{ github.ref_name == 'production' }}
         uses: actions-ecosystem/action-get-latest-tag@v1
         with:
           semver_only: false
       - name: Get second latest tag
         id: get_second_latest_tag
+        if: ${{ github.ref_name == 'production' }}
         run: |
           SECOND_LATEST_TAG=$(git for-each-ref --sort=-taggerdate --format '%(refname:short)' refs/tags | sed -n 2p)
           echo "second_latest_tag=$SECOND_LATEST_TAG" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG
         id: changelog
+        if: ${{ github.ref_name == 'production' }}
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
@@ -52,6 +59,7 @@ jobs:
           excludeTypes: build,
           reverseOrder: true
       - name: Create Release
+        if: ${{ github.ref_name == 'production' }}
         uses: ncipollo/release-action@v1.12.0
         with:
           allowUpdates: true
@@ -62,6 +70,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.get_latest_tag.outputs.tag }}
       - name: Commit CHANGELOG.md
+        if: ${{ github.ref_name == 'production' }} 
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: preprod
@@ -71,6 +80,7 @@ jobs:
         id: timestamp
         run: echo "NOW_MS=$(date +%s%3N)" >> $GITHUB_OUTPUT
       - name: Set New Relic deployment marker
+        if: ${{ github.ref_name == 'production' }}
         uses: newrelic/deployment-marker-action@v2.6.1
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
@@ -80,4 +90,31 @@ jobs:
           changelog: "https://github.com/${{ github.repository }}/blob/preprod/CHANGELOG.md"
           description: "Automated Release via Github Actions"
           user: "${{ github.actor }}"
+          timestamp: "${{ steps.timestamp.outputs.NOW_MS }}"
+
+      # Set New Relic deployment marker for Preprod.
+      # Requires NEW_RELIC_PREPROD_ENTITY_GUID secret to be set.
+
+      # Get commit info for changelog and user.
+      - name: Get commit info
+        id: commit_info
+        if: ${{ github.ref_name == 'preprod' && secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
+        run: |
+          CHANGELOG=$(git log ${{ github.sha }} --oneline -1)
+          USER=$(git log ${{ github.sha }} --format="%an" -1)
+          echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "user=$USER" >> $GITHUB_OUTPUT
+
+      # Set the Preprod Marker.
+      - name: Set Preprod New Relic deployment marker
+        if: ${{ github.ref_name == 'preprod' && secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
+        uses: newrelic/deployment-marker-action@v2.6.1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: "US"
+          guid: ${{ secrets.NEW_RELIC_PREPROD_ENTITY_GUID }}
+          version: "${{ github.sha }}"
+          changelog: "${{ steps.commit_info.outputs.changelog }}"
+          description: "Release via Github Actions"
+          user: "${{ steps.commit_info.outputs.user }}"
           timestamp: "${{ steps.timestamp.outputs.NOW_MS }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_call:
+    inputs:
+      update_wiki:
+        required: false
+        type: boolean
+        default: false
     secrets:
       NEW_RELIC_API_KEY:
         required: true
@@ -76,6 +81,32 @@ jobs:
           branch: preprod
           commit_message: 'docs: update CHANGELOG.md for ${{ steps.get_latest_tag.outputs.tag }} [skip ci]'
           file_pattern: CHANGELOG.md
+
+      - name: Update Wiki
+        if: ${{ github.ref_name == 'production' && inputs.update_wiki }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(git log ${{ github.sha }} --grep='Merge pull request' --pretty=format:'%s' -1 | grep -o '#[0-9]\+')
+          PR_URL="[[${{ github.repository }}${PR_NUMBER:1}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER:1})]"
+
+          # Note: This will only run on production so no need for conditional.
+          DATE=$(date '+%-d %B %Y')
+          MESSAGE="\r***\n**$DATE**"
+
+          CL_ENTRY="$MESSAGE $PR_URL\n"
+
+          # Note: Need to use HTTPS to access in GH Actions. Also use dynamic
+          # repository path to allow for forked repo usage.
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git $(basename ${{ github.repository }}).wiki
+          cd $(basename ${{ github.repository }}).wiki
+          git config user.name "GitHub Actions"
+          git config user.email "dmg-github@dmgmedia.co.uk"
+          echo -e "$CL_ENTRY$(cat Change-Log.md)" > Change-Log.md
+          git add .
+          git commit -m "Updated Change-Log.md"
+          git push
+
       - name: Get current timestamp in milliseconds for deployment marker
         id: timestamp
         run: echo "NOW_MS=$(date +%s%3N)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_call:
     inputs:
-      update_changelog:
+      commit_changelog:
         required: false
         type: boolean
         default: false
@@ -57,7 +57,7 @@ jobs:
           echo "second_latest_tag=$SECOND_LATEST_TAG" >> "$GITHUB_OUTPUT"
       - name: Update CHANGELOG
         id: changelog
-        if: ${{ github.ref_name == 'production' && inputs.update_changelog }}
+        if: ${{ github.ref_name == 'production' }}
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.get_latest_tag.outputs.tag }}
       - name: Commit CHANGELOG.md
-        if: ${{ github.ref_name == 'production' }} 
+        if: ${{ github.ref_name == 'production' && inputs.commit_changelog }} 
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           branch: preprod
@@ -92,7 +92,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=$(git log ${{ github.sha }} --grep='Merge pull request' --pretty=format:'%s' -1 | grep -o '#[0-9]\+')
-          PR_URL="[[${{ github.repository }}${PR_NUMBER:1}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER:1})]"
+          PR_URL="[${{ github.repository }}#${PR_NUMBER:1}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER:1})"
 
           # Note: This will only run on production so no need for conditional.
           DATE=$(date '+%-d %B %Y')


### PR DESCRIPTION
Addresses: https://anm508a.atlassian.net/browse/INEWS-2894

Changes made based on recommendations in implementation PR: https://github.com/wpcomvip/inews/pull/2304#pullrequestreview-3330893956

This PR:

- Adds support for creating an NR marker when deploying to `preprod`
- Adds support and a conditional for updating the Changelog wiki entry in GitHub
- Adds a conditional so committing the Changelog file is optional