### PR TITLE
[fix/reset-environments] Trying fix for Reset Environments step

### DIFF
--- a/.github/workflows/reset.yml
+++ b/.github/workflows/reset.yml
@@ -16,31 +16,32 @@ jobs:
       - name: Reset Branch
         if: ${{ github.ref_name == 'develop' || github.ref_name == 'test1' || github.ref_name == 'test2' || github.ref_name == 'test3' || github.ref_name == 'test4' }}
         run: |
-            git config user.name "$( git log --format=%cn -n 1 ${{github.sha}} )"
-            git config user.email "$( git log --format=%ce -n 1 ${{github.sha}} )"
-            git fetch origin
-            git reset --hard origin/production --
-            echo "${{github.ref_name}} hard reset on $(date)" > reset.txt
-            echo -e "\n$(git log -n 1 origin/production)" >> reset.txt
-            git add .
-            git commit -m "[skip ci] ${{github.ref_name}} - [skip ci] git reset --hard origin/production" --no-verify
-            git push -f origin ${{github.ref_name}}
+          git config user.name "$( git log --format=%cn -n 1 ${{github.sha}} )"
+          git config user.email "$( git log --format=%ce -n 1 ${{github.sha}} )"
+          git fetch origin
+          git reset --hard origin/production --
+          echo "${{github.ref_name}} hard reset on $(date)" > reset.txt
+          echo -e "\n$(git log -n 1 origin/production)" >> reset.txt
+          git add .
+          git commit -m "[skip ci] ${{github.ref_name}} - [skip ci] git reset --hard origin/production" --no-verify
+          git push -f origin ${{github.ref_name}}
       # After a prod deployment, reset all test branches to the production code
       - name: Reset Environments
         if: ${{ github.ref_name == 'production' }}
         run: |
-            git config user.name "$( git log --format=%cn -n 1 ${{github.sha}} )"
-            git config user.email "$( git log --format=%ce -n 1 ${{github.sha}} )"
-            export TEST_ENVS=('test1' 'test2' 'test3' 'test4' 'develop')
-            for test_env in ${TEST_ENVS[@]}; do
-              if git show-ref --quiet refs/heads/$test_env; then
-                git fetch origin  
-                git checkout $test_env --
-                git reset --hard origin/production --
-                echo "$test_env hard reset on $(date)" > reset.txt
-                echo -e "\n$(git log -n 1 origin/production)" >> reset.txt
-                git add .
-                git commit -m "[skip ci] $test_env - [skip ci] git reset --hard origin/production" --no-verify
-                git push -f origin $test_env
-              fi
-            done
+          git config user.name "$( git log --format=%cn -n 1 ${{github.sha}} )"
+          git config user.email "$( git log --format=%ce -n 1 ${{github.sha}} )"
+          git fetch origin
+          export TEST_ENVS=('test1' 'test2' 'test3' 'test4' 'develop')
+          for test_env in ${TEST_ENVS[@]}; do
+            if git show-ref --quiet refs/remotes/origin/$test_env; then
+              echo "Resetting branch $test_env"
+              git checkout -B $test_env origin/$test_env
+              git reset --hard origin/production
+              echo "$test_env hard reset on $(date)" > reset.txt
+              echo -e "\n$(git log -n 1 origin/production)" >> reset.txt
+              git add .
+              git commit -m "[skip ci] $test_env - [skip ci] git reset --hard origin/production" --no-verify
+              git push -f origin $test_env && echo "Push succeeded for $test_env" || echo "Push failed for $test_env"
+            fi
+          done


### PR DESCRIPTION
IMPORTANT: Change the reference to this branch added in the Metro workflow in https://github.com/wpcomvip/metro/pull/8071 back to `@main` when merging this PR and before deleting this branch.

* The step wasn't running, possibly because it wasn't finding  `refs/heads/$test_env`. Checking `git show-ref --quiet refs/remotes/origin/$test_env` instead.
* Running `git fetch origin` once outside the loop.
* Doing `git checkout -B $test_env origin/$test_env` to overwrite each branch with the origin version on checking out/creating.
* Added output lines for debugging.