### PR TITLE
Pass `GITHUB_COMMIT_PAT` secret to "Checkout code" step to allow us to push changelog commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
         with:
+          # Optionally pass the GITHUB_COMMIT_PAT secret to allow changelog to be pushed to a protected branch.
+          token: ${{ secrets.GITHUB_COMMIT_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       # Create git tag from timestamp YYYY-MM-DDTHH:MM:SS


### PR DESCRIPTION
We need to create a [GitHub PAT](https://github.com/settings/personal-access-tokens) and set up a `GITHUB_COMMIT_PAT` secret in the [Metro repo](https://github.com/wpcomvip/metro/settings/secrets/actions). The [docs](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches) say:

* "You need a Personal Access Token and you either have to allow force pushes or the Personal Access Token needs to belong to an Administrator."
* If it's a classic personal access token, apply the `repo` and `workflow` scopes. If it's a fine-grained personal access token, apply the `Contents` permissions.

Mike recommended the `dmg-github` account as one we could try with.